### PR TITLE
Remove mb_chars for Rails 8.1 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,15 @@
 version: 2.1
 
-orbs:
-  ruby: circleci/ruby@1.4.0
-
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.0.1
+      - image: cimg/ruby:3.4.8
     steps:
       - checkout
-      - ruby/install-deps
-      - ruby/rspec-test
+      - run: bundle install
+      - run: bundle exec rspec
 
 workflows:
-  version: 2
   build_and_test:
     jobs:
       - build

--- a/dejunk.gemspec
+++ b/dejunk.gemspec
@@ -6,7 +6,7 @@ require 'dejunk/version'
 Gem::Specification.new do |spec|
   spec.name          = "dejunk"
   spec.version       = Dejunk::VERSION
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 3.3'
   spec.authors       = ["David Judd"]
   spec.email         = ["david@academia.edu"]
 

--- a/dejunk.gemspec
+++ b/dejunk.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
 
-  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec"
 end

--- a/dejunk.gemspec
+++ b/dejunk.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport'
 
-  spec.add_development_dependency "rake", "~> 12.3.3"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end

--- a/lib/dejunk.rb
+++ b/lib/dejunk.rb
@@ -1,6 +1,8 @@
 require "dejunk/version"
 require "yaml"
+require 'bigdecimal'
 require "active_support/core_ext/string"
+require "active_support/core_ext/object/blank"
 
 module Dejunk
   extend self

--- a/lib/dejunk.rb
+++ b/lib/dejunk.rb
@@ -1,8 +1,9 @@
-require "dejunk/version"
-require "yaml"
-require 'bigdecimal'
-require "active_support/core_ext/string"
 require "active_support/core_ext/object/blank"
+require "active_support/core_ext/string"
+require "bigdecimal"
+require "yaml"
+
+require "dejunk/version"
 
 module Dejunk
   extend self

--- a/lib/dejunk.rb
+++ b/lib/dejunk.rb
@@ -113,7 +113,7 @@ module Dejunk
     string.
       chars.
       zip(string.chars[1..-1]).
-      map { |c1,c2| "#{c1.mb_chars.downcase}#{c2.mb_chars.downcase}" if c1 && c2 }.
+      map { |c1,c2| "#{c1.downcase}#{c2.downcase}" if c1 && c2 }.
       compact.
       map { |bigram| bigram.gsub(/[0-9]/, '0'.freeze) }.
       map { |bigram| bigram.gsub(/[[:space:]]/, ' '.freeze) }
@@ -144,8 +144,12 @@ module Dejunk
   end
 
   def normalize_for_comparison(string)
+    # This mirrors what mb_chars did, assuming that non-UTF-8 encoded strings
+    # are actually UTF-8 in disguise. It's unclear whether this is necessary,
+    # but we left it in to avoid having to figure this out.
+    string = string.dup.force_encoding(Encoding::UTF_8) if string.encoding != Encoding::UTF_8
+
     string.
-      mb_chars.
       unicode_normalize(:nfkd).
       gsub(/\p{Mn}+/, ''.freeze).
       gsub(/[^[:alnum:]]+/, ''.freeze).

--- a/lib/dejunk/version.rb
+++ b/lib/dejunk/version.rb
@@ -1,3 +1,3 @@
 module Dejunk
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
Rails 8.1 deprecates the mb_chars String extension from ActiveSupport. This was deprecated [here](https://github.com/rails/rails/pull/54081) without too much explanation. 

I was able to verify that using mb_chars under activesupport 8.1 makes the `is_junk?` method significantly slower, even with deprecation warnings silenced.

Here are my benchmark results (this is Benchmark.ips (iterations per second) so higher is better):
```
  ┌───────────────────────────────────┬────────────────┬────────────────┬───────────────┬───────────────┐                                                                               
  │              Variant              │ 8.0.5 is_junk? │ 8.1.3 is_junk? │ 8.0.5 bigrams │ 8.1.3 bigrams │                                                                               
  ├───────────────────────────────────┼────────────────┼────────────────┼───────────────┼───────────────┤                                                                               
  │ Original (String#mb_chars)        │          272.1 │           56.4 │         18.3k │          2.2k │                                                                               
  ├───────────────────────────────────┼────────────────┼────────────────┼───────────────┼───────────────┤                                                                               
  │ New                               │          377.1 │          375.3 │         42.6k │         41.1k │                                                                               
  └───────────────────────────────────┴────────────────┴────────────────┴───────────────┴───────────────┘                                                                               
                                                            
```